### PR TITLE
[Feature] IDDFSSearchStrategy and GPSEngine improvements

### DIFF
--- a/src/main/java/ar/edu/itba/sia/gps/AbstractSearchStrategy.java
+++ b/src/main/java/ar/edu/itba/sia/gps/AbstractSearchStrategy.java
@@ -4,12 +4,26 @@ import java.util.Map;
 import java.util.HashMap;
 import  ar.edu.itba.sia.gps.api.GPSState;
 import java.util.Collection;
+import java.util.Queue;
 
 public abstract class AbstractSearchStrategy implements ISearchStrategy {
   private Map<GPSState, Integer> bestCosts;
+  private Queue<GPSNode> open;
 
   public AbstractSearchStrategy() {
     bestCosts = new HashMap<>();
+  }
+
+  public void setOpen(Queue<GPSNode> open) {
+    this.open = open;
+  }
+
+  public Queue<GPSNode> getOpen() {
+    return open;
+  }
+
+  public Map<GPSState, Integer> getBestCosts() {
+    return bestCosts;
   }
 
   public void addNode(GPSNode node) {

--- a/src/main/java/ar/edu/itba/sia/gps/GPSEngine.java
+++ b/src/main/java/ar/edu/itba/sia/gps/GPSEngine.java
@@ -55,7 +55,7 @@ public class GPSEngine {
     switch (strategy) {
       case DFS: return new DFSSearchStrategy();
       case BFS: return new BFSSearchStrategy();
-      case IDDFS: return null;
+      case IDDFS: return new IDDFSSearchStrategy();
       case GREEDYSEARCH: return new GreedySearchStrategy(problem::getHValue);
       case ASTAR: return new AStarSearchStrategy(problem::getHValue);
       default: return null;

--- a/src/main/java/ar/edu/itba/sia/gps/GPSEngine.java
+++ b/src/main/java/ar/edu/itba/sia/gps/GPSEngine.java
@@ -14,8 +14,7 @@ import ar.edu.itba.sia.gps.api.GPSState;
 import ar.edu.itba.sia.gps.strategies.*;
 
 public class GPSEngine {
-  private Queue<GPSNode> open;
-  private Map<GPSState, Integer> bestCosts;
+
   private GPSProblem problem;
   private long explosionCounter;
   private boolean finished;
@@ -65,11 +64,11 @@ public class GPSEngine {
   // GETTERS FOR THE PEOPLE!
 
   public Queue<GPSNode> getOpen() {
-    return open;
+    return strategyObject.getOpen();
   }
 
   public Map<GPSState, Integer> getBestCosts() {
-    return bestCosts;
+    return strategyObject.getBestCosts();
   }
 
   public GPSProblem getProblem() {

--- a/src/main/java/ar/edu/itba/sia/gps/GPSNode.java
+++ b/src/main/java/ar/edu/itba/sia/gps/GPSNode.java
@@ -10,15 +10,21 @@ public class GPSNode {
   private GPSState state;
   private GPSNode parent;
   private Integer cost;
+  private Integer level;
 
   public GPSNode(GPSState state, Integer cost) {
-    this(state, cost, null);
+    this(state, cost, null, 0);
   }
 
-  public GPSNode(GPSState state, Integer cost, GPSNode parent) {
+  public GPSNode(GPSState state, Integer cost, GPSNode parent, Integer level) {
     this.state = state;
     this.cost = cost;
     this.parent = parent;
+    this.level = level;
+  }
+
+  public Integer getLevel() {
+    return level;
   }
 
   public GPSNode getParent() {
@@ -56,8 +62,9 @@ public class GPSNode {
     Collection<GPSNode> neighbors = new LinkedList<>();
     for (GPSRule rule : rules) {
       Optional<GPSState> newState = rule.evalRule(this.getState());
+      //FIXME: ver si pasarle el level asi está ok.
       newState.ifPresent(
-        (state) -> neighbors.add(new GPSNode(state, cost + rule.getCost(), this))
+        (state) -> neighbors.add(new GPSNode(state, cost + rule.getCost(), this, level+1))
       );
     }
     return neighbors;

--- a/src/main/java/ar/edu/itba/sia/gps/ISearchStrategy.java
+++ b/src/main/java/ar/edu/itba/sia/gps/ISearchStrategy.java
@@ -1,6 +1,10 @@
 package  ar.edu.itba.sia.gps;
 
+import ar.edu.itba.sia.gps.api.GPSState;
+
 import java.util.Collection;
+import java.util.Map;
+import java.util.Queue;
 
 public interface ISearchStrategy {
   void addNode(GPSNode node);
@@ -8,4 +12,6 @@ public interface ISearchStrategy {
   boolean expanded(GPSNode node);
   boolean hasNextNode();
   GPSNode removeNextNode();
+  Queue<GPSNode> getOpen();
+  Map<GPSState, Integer> getBestCosts();
 }

--- a/src/main/java/ar/edu/itba/sia/gps/strategies/AStarSearchStrategy.java
+++ b/src/main/java/ar/edu/itba/sia/gps/strategies/AStarSearchStrategy.java
@@ -14,6 +14,7 @@ public class AStarSearchStrategy extends AbstractSearchStrategy {
     nodes = new PriorityQueue<>(
       (a, b) -> (b.getCost() + heuristic.apply(b.getState())) - (a.getCost() + heuristic.apply(a.getState()))
     );
+    setOpen(nodes);
   }
 
   @Override

--- a/src/main/java/ar/edu/itba/sia/gps/strategies/BFSSearchStrategy.java
+++ b/src/main/java/ar/edu/itba/sia/gps/strategies/BFSSearchStrategy.java
@@ -10,6 +10,7 @@ public class BFSSearchStrategy extends AbstractSearchStrategy {
   public BFSSearchStrategy() {
     super();
     nodes = new LinkedList<>();
+    setOpen(nodes);
   }
 
   public void concreteAddNode(GPSNode node) {

--- a/src/main/java/ar/edu/itba/sia/gps/strategies/DFSSearchStrategy.java
+++ b/src/main/java/ar/edu/itba/sia/gps/strategies/DFSSearchStrategy.java
@@ -6,7 +6,9 @@ import java.util.Deque;
 import java.util.LinkedList;
 
 public class DFSSearchStrategy extends AbstractSearchStrategy {
-  Deque<GPSNode> nodes;
+
+  private Deque<GPSNode> nodes;
+
   public DFSSearchStrategy() {
     super();
     nodes = new LinkedList<>();

--- a/src/main/java/ar/edu/itba/sia/gps/strategies/DFSSearchStrategy.java
+++ b/src/main/java/ar/edu/itba/sia/gps/strategies/DFSSearchStrategy.java
@@ -4,6 +4,7 @@ import  ar.edu.itba.sia.gps.AbstractSearchStrategy;
 import  ar.edu.itba.sia.gps.GPSNode;
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.Queue;
 
 public class DFSSearchStrategy extends AbstractSearchStrategy {
 
@@ -12,6 +13,7 @@ public class DFSSearchStrategy extends AbstractSearchStrategy {
   public DFSSearchStrategy() {
     super();
     nodes = new LinkedList<>();
+    setOpen(nodes);
   }
 
   @Override

--- a/src/main/java/ar/edu/itba/sia/gps/strategies/GreedySearchStrategy.java
+++ b/src/main/java/ar/edu/itba/sia/gps/strategies/GreedySearchStrategy.java
@@ -14,6 +14,7 @@ public class GreedySearchStrategy extends AbstractSearchStrategy {
     nodes = new PriorityQueue<>(
       (a, b) -> heuristic.apply(b.getState()) - heuristic.apply(a.getState())
     );
+    setOpen(nodes);
   }
 
   @Override

--- a/src/main/java/ar/edu/itba/sia/gps/strategies/IDDFSSearchStrategy.java
+++ b/src/main/java/ar/edu/itba/sia/gps/strategies/IDDFSSearchStrategy.java
@@ -18,6 +18,7 @@ public class IDDFSSearchStrategy  extends AbstractSearchStrategy {
     super();
     this.nodes = new LinkedList<>();
     this.depthBound = 0;
+    setOpen(nodes);
   }
 
   @Override

--- a/src/main/java/ar/edu/itba/sia/gps/strategies/IDDFSSearchStrategy.java
+++ b/src/main/java/ar/edu/itba/sia/gps/strategies/IDDFSSearchStrategy.java
@@ -1,0 +1,40 @@
+package ar.edu.itba.sia.gps.strategies;
+
+import ar.edu.itba.sia.gps.AbstractSearchStrategy;
+import ar.edu.itba.sia.gps.GPSNode;
+
+import java.util.Deque;
+import java.util.LinkedList;
+
+/**
+ * Created by marlanti on 3/28/17.
+ */
+public class IDDFSSearchStrategy  extends AbstractSearchStrategy {
+
+  private Deque<GPSNode> nodes;
+  private Integer depthBound;
+
+  public IDDFSSearchStrategy() {
+    super();
+    this.nodes = new LinkedList<>();
+    this.depthBound = 0;
+  }
+
+  @Override
+  public boolean hasNextNode() {
+    return !nodes.isEmpty();
+  }
+
+  @Override
+  protected void concreteAddNode(GPSNode node) {
+    if(node.getLevel() < depthBound){
+      nodes.addFirst(node);
+    }
+    depthBound++;
+  }
+
+  @Override
+  public GPSNode removeNextNode() {
+    return nodes.remove();
+  }
+}


### PR DESCRIPTION
## IDDFSSearchStrategy added

- Stack implemented with Dequeue
- Level added to GPSNode
- concreteAddNode(GPSNode node) manages logic to expand or not a node depending on its level and depthBound

## open and bestCosts now can be get from GPSEngine

- AbstractSearchStrategy now contains Queue<GPSNode> open and its getter.
- open is set from concrete Strategies constructors.